### PR TITLE
Add minimal web UI for deposits

### DIFF
--- a/deposit_utils.py
+++ b/deposit_utils.py
@@ -1,0 +1,118 @@
+import json
+from typing import Optional
+
+from web3 import Web3
+from eth_account import Account
+from py_ecc.bls import G2ProofOfPossession as bls
+
+import deposit as dep
+
+# Deposit contract constants
+DEPOSIT_CONTRACT_ADDRESS = Web3.to_checksum_address("0x00000000219ab540356cBB839Cbe05303d7705Fa")
+DEPOSIT_ABI = [
+    {
+        "inputs": [
+            {"internalType": "bytes", "name": "pubkey", "type": "bytes"},
+            {"internalType": "bytes", "name": "withdrawal_credentials", "type": "bytes"},
+            {"internalType": "bytes", "name": "signature", "type": "bytes"},
+            {"internalType": "bytes32", "name": "deposit_data_root", "type": "bytes32"},
+        ],
+        "name": "deposit",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    }
+]
+
+
+def generate_deposit(
+    pubkey_hex: str,
+    eth1_address: str,
+    amount_gwei: int,
+    keystore_path: str,
+    password: str,
+    output_file: Optional[str] = None,
+) -> dict:
+    """Create deposit JSON data from validator pubkey/keystore."""
+    pubkey = dep.hex_to_bytes(pubkey_hex, expected_len=48, field_name="pubkey")
+    withdrawal_credentials = dep.make_withdrawal_credentials(eth1_address)
+
+    privkey_bytes = dep.decrypt_keystore(keystore_path, password)
+    if len(privkey_bytes) != 32:
+        raise ValueError("Decrypted private key must be exactly 32 bytes")
+    privkey = int.from_bytes(privkey_bytes, "big")
+
+    deposit_message_root = dep.compute_deposit_message_root(
+        pubkey, withdrawal_credentials, amount_gwei
+    )
+    signing_root = dep.sha256(deposit_message_root + dep.compute_deposit_domain())
+    signature = bls.Sign(privkey, signing_root)
+    deposit_data_root = dep.compute_deposit_data_root(
+        pubkey, withdrawal_credentials, amount_gwei, signature
+    )
+
+    deposit_json = {
+        "pubkey": f"0x{pubkey.hex()}",
+        "withdrawal_credentials": f"0x{withdrawal_credentials.hex()}",
+        "amount": amount_gwei,
+        "signature": f"0x{signature.hex()}",
+        "deposit_message_root": f"0x{deposit_message_root.hex()}",
+        "deposit_data_root": f"0x{deposit_data_root.hex()}",
+    }
+
+    if output_file:
+        with open(output_file, "w") as f:
+            json.dump(deposit_json, f, indent=4)
+
+    return deposit_json
+
+
+def parse_deposit_data(deposit: dict) -> dict:
+    """Parse deposit JSON dictionary and return binary values."""
+    return {
+        "pubkey": dep.hex_to_bytes(deposit["pubkey"], 48, "pubkey"),
+        "withdrawal_credentials": dep.hex_to_bytes(
+            deposit["withdrawal_credentials"], 32, "withdrawal_credentials"
+        ),
+        "amount": int(deposit["amount"]),
+        "signature": dep.hex_to_bytes(deposit["signature"], 96, "signature"),
+        "deposit_data_root": dep.hex_to_bytes(
+            deposit["deposit_data_root"], 32, "deposit_data_root"
+        ),
+    }
+
+
+def send_deposit(
+    privkey: str, deposit: dict, eth_rpc_url: str = "https://rpc.hoodi.ethpandaops.io"
+) -> str:
+    """Send deposit transaction to the network and return tx hash."""
+    w3 = Web3(Web3.HTTPProvider(eth_rpc_url))
+    if not w3.is_connected():
+        raise RuntimeError(f"Cannot connect to Ethereum node: {eth_rpc_url}")
+
+    account = Account.from_key(privkey)
+    deposit_data = parse_deposit_data(deposit)
+
+    contract = w3.eth.contract(address=DEPOSIT_CONTRACT_ADDRESS, abi=DEPOSIT_ABI)
+    nonce = w3.eth.get_transaction_count(account.address)
+    value = deposit_data["amount"] * 10**9
+
+    txn = contract.functions.deposit(
+        deposit_data["pubkey"],
+        deposit_data["withdrawal_credentials"],
+        deposit_data["signature"],
+        deposit_data["deposit_data_root"],
+    ).build_transaction(
+        {
+            "from": account.address,
+            "value": value,
+            "nonce": nonce,
+            "gasPrice": w3.eth.gas_price,
+            "chainId": w3.eth.chain_id,
+        }
+    )
+
+    txn["gas"] = w3.eth.estimate_gas(txn)
+    signed_txn = account.sign_transaction(txn)
+    tx_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+    return tx_hash.hex()

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Hoodi Depositor</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        section { margin-bottom: 2em; }
+        label { display: block; margin-top: 0.5em; }
+        input, select { width: 100%; padding: 0.4em; }
+        button { margin-top: 1em; padding: 0.5em 1em; }
+        pre { background: #f0f0f0; padding: 1em; overflow-x: auto; }
+    </style>
+</head>
+<body>
+<h1>Hoodi Depositor</h1>
+<section>
+    <h2>Wallets</h2>
+    <select id="wallet-select"></select>
+    <button onclick="refreshWallets()">Refresh Wallets</button>
+</section>
+
+<section>
+    <h2>Generate Keystore</h2>
+    <label>Index <input id="ks-index" type="number" value="0"></label>
+    <label>Num Validators <input id="ks-num" type="number" value="1"></label>
+    <label>Mnemonic (optional) <input id="ks-mnemonic" type="text"></label>
+    <label>Chain <input id="ks-chain" type="text" value="hoodi"></label>
+    <label>Output Directory <input id="ks-dir" type="text" value="validator_keys"></label>
+    <button onclick="generateKeystore()">Generate</button>
+    <pre id="ks-output"></pre>
+</section>
+
+<section>
+    <h2>Generate Deposit Data</h2>
+    <label>Validator Pubkey <input id="pubkey" type="text"></label>
+    <label>Withdrawal Address <input id="withdrawal" type="text"></label>
+    <label>Amount (gwei) <input id="amount" type="number" value="32000000000"></label>
+    <label>Keystore File <input id="keystore" type="file"></label>
+    <label>Password <input id="password" type="password"></label>
+    <button onclick="generateDeposit()">Generate</button>
+    <pre id="deposit-output"></pre>
+</section>
+
+<section>
+    <h2>Send Deposit</h2>
+    <button onclick="sendDeposit()">Send Deposit Transaction</button>
+    <pre id="tx-output"></pre>
+</section>
+
+<script>
+async function refreshWallets() {
+    const res = await fetch('/wallets');
+    const wallets = await res.json();
+    const sel = document.getElementById('wallet-select');
+    sel.innerHTML = '';
+    wallets.forEach(w => {
+        const opt = document.createElement('option');
+        opt.value = w.address;
+        opt.textContent = w.address;
+        sel.appendChild(opt);
+    });
+}
+
+async function generateDeposit() {
+    const pubkey = document.getElementById('pubkey').value;
+    const withdrawal = document.getElementById('withdrawal').value;
+    const amount = document.getElementById('amount').value;
+    const fileInput = document.getElementById('keystore');
+    const password = document.getElementById('password').value;
+    if (!fileInput.files.length) { alert('Select keystore file'); return; }
+    const form = new FormData();
+    form.append('pubkey', pubkey);
+    form.append('withdrawal', withdrawal);
+    form.append('amount', amount);
+    form.append('password', password);
+    form.append('keystore', fileInput.files[0]);
+    const res = await fetch('/generate_deposit', { method: 'POST', body: form });
+    const data = await res.json();
+    document.getElementById('deposit-output').textContent = JSON.stringify(data, null, 2);
+    window.currentDeposit = data;
+}
+
+async function sendDeposit() {
+    if (!window.currentDeposit) { alert('Generate deposit first'); return; }
+    const address = document.getElementById('wallet-select').value;
+    const res = await fetch('/send_deposit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: address, deposit: window.currentDeposit })
+    });
+    const data = await res.json();
+    document.getElementById('tx-output').textContent = JSON.stringify(data, null, 2);
+}
+
+async function generateKeystore() {
+    const payload = {
+        index: parseInt(document.getElementById('ks-index').value),
+        num_validators: parseInt(document.getElementById('ks-num').value),
+        mnemonic: document.getElementById('ks-mnemonic').value || null,
+        chain: document.getElementById('ks-chain').value,
+        output_dir: document.getElementById('ks-dir').value
+    };
+    const res = await fetch('/generate_keystore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    document.getElementById('ks-output').textContent = JSON.stringify(data, null, 2);
+}
+
+refreshWallets();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `deposit_utils.py` with helper functions to create and send deposit data
- serve a static HTML interface via FastAPI
- expose new API routes for generating keystores, deposit JSON and sending deposit tx

## Testing
- `python -m py_compile main.py deposit_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686d189948b8832c9c8d7aa522087db0