### PR TITLE
Replace nimbus_cli in keystore endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ eth-account==0.5.9
 py-ecc==4.0.0
 click==7.0
 pycryptodome==3.9.7
+mnemonic==0.21
+eth2deposit==0.2.2


### PR DESCRIPTION
## Summary
- generate keystores directly in `api_generate_keystore`
- use `mnemonic` and `eth2deposit` libraries
- list the new dependencies in `requirements.txt`
- handle empty mnemonic strings when generating keystores

## Testing
- `python -m py_compile main.py deposit_utils.py deposit.py send_deposit_tx.py`

------
https://chatgpt.com/codex/tasks/task_e_686d2bc91720832ca54f1bd540e6c7de