### PR TITLE
Add keystore management page

### DIFF
--- a/static/keystores.html
+++ b/static/keystores.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Keystore Depositor</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+    <style>
+        body { margin: 40px; }
+        section { margin-bottom: 2em; }
+        pre { background: #f0f0f0; padding: 1em; overflow-x: auto; }
+    </style>
+</head>
+<body>
+<h1>Keystore Depositor</h1>
+<section>
+    <h2>Wallets</h2>
+    <table class="table" id="wallet-table">
+        <thead><tr><th>Address</th><th>Balance (ETH)</th></tr></thead>
+        <tbody></tbody>
+    </table>
+    <select id="wallet-select" class="form-select d-none"></select>
+    <button class="btn btn-secondary" onclick="refreshWallets()">Refresh Wallets</button>
+</section>
+<section>
+    <h2>Browse Keystores</h2>
+    <label class="form-label">Folder <input class="form-control" id="ks-folder" type="text" value="validator_keys"></label>
+    <label class="form-label">Password <input class="form-control" id="ks-password" type="password" value="password"></label>
+    <button class="btn btn-primary" onclick="loadKeystores()">Load Keystores</button>
+    <table class="table mt-3" id="ks-table">
+        <thead><tr><th>Keystore</th><th>Status</th><th></th></tr></thead>
+        <tbody></tbody>
+    </table>
+    <pre id="ks-log"></pre>
+</section>
+<script>
+function log(msg){
+    const pre=document.getElementById('ks-log');
+    pre.textContent += msg + "\n";
+}
+async function refreshWallets(){
+    const res=await fetch('/wallets');
+    const wallets=await res.json();
+    const sel=document.getElementById('wallet-select');
+    const tbody=document.querySelector('#wallet-table tbody');
+    sel.innerHTML='';
+    tbody.innerHTML='';
+    wallets.forEach(w=>{
+        const opt=document.createElement('option');
+        opt.value=w.address; opt.textContent=w.address; sel.appendChild(opt);
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${w.address}</td><td>${w.balance}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+async function loadKeystores(){
+    const dir=document.getElementById('ks-folder').value;
+    const res=await fetch('/list_keystores?path='+encodeURIComponent(dir));
+    const list=await res.json();
+    const tbody=document.querySelector('#ks-table tbody');
+    tbody.innerHTML='';
+    list.forEach(ks=>{
+        const tr=document.createElement('tr');
+        let status= ks.used ? `Used - ${ks.tx_hash}` : 'Unused';
+        let btn = ks.used ? '' : `<button class="btn btn-sm btn-success" onclick="depositKS('${ks.path}')">Deposit</button>`;
+        tr.innerHTML=`<td>${ks.path}</td><td>${status}</td><td>${btn}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+async function depositKS(path){
+    const addr=document.getElementById('wallet-select').value;
+    const pwd=document.getElementById('ks-password').value;
+    log('Depositing '+path);
+    const res=await fetch('/deposit_keystore',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({address:addr,keystore_path:path,password:pwd})});
+    const data=await res.json();
+    if(data.tx_hash){
+        log('Tx '+data.tx_hash);
+    }
+    if(data.already_used){
+        log('Keystore already used');
+    }
+    loadKeystores();
+}
+refreshWallets();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add persistent database folder
- include helper functions to load/save keystore deposit status
- expose endpoints to list keystores and deposit using them
- provide new `/keystores_page` UI

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
import main
print('ok')
PY` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*


------
https://chatgpt.com/codex/tasks/task_e_686d339bca98832cab10feffc2154f47