### PR TITLE
Read password from secrets

### DIFF
--- a/main.py
+++ b/main.py
@@ -464,7 +464,6 @@ async def api_list_keystores(path: str):
 class KeystoreDepositRequest(BaseModel):
     address: str
     keystore_path: str
-    password: str = 'password'
     amount: int = 32000000000
 
 
@@ -482,7 +481,10 @@ async def api_deposit_keystore(req: KeystoreDepositRequest):
         return {'tx_hash': used[req.keystore_path], 'already_used': True}
 
     try:
-        deposit = generate_deposit(None, wallet['address'], req.amount, req.keystore_path, req.password)
+        pwd_path = os.path.join(os.path.dirname(req.keystore_path), 'secrets', req.address)
+        with open(pwd_path, 'r') as pf:
+            password = pf.read().strip()
+        deposit = generate_deposit(None, wallet['address'], req.amount, req.keystore_path, password)
         tx_hash = send_deposit(wallet['privateKey'], deposit)
         used[req.keystore_path] = tx_hash
         db['used_keystores'] = used

--- a/static/keystores.html
+++ b/static/keystores.html
@@ -24,7 +24,6 @@
 <section>
     <h2>Browse Keystores</h2>
     <label class="form-label">Folder <input class="form-control" id="ks-folder" type="text" value="validator_keys"></label>
-    <label class="form-label">Password <input class="form-control" id="ks-password" type="password" value="password"></label>
     <button class="btn btn-primary" onclick="loadKeystores()">Load Keystores</button>
     <table class="table mt-3" id="ks-table">
         <thead><tr><th>Keystore</th><th>Status</th><th></th></tr></thead>
@@ -68,9 +67,8 @@ async function loadKeystores(){
 }
 async function depositKS(path){
     const addr=document.getElementById('wallet-select').value;
-    const pwd=document.getElementById('ks-password').value;
     log('Depositing '+path);
-    const res=await fetch('/deposit_keystore',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({address:addr,keystore_path:path,password:pwd})});
+    const res=await fetch('/deposit_keystore',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({address:addr,keystore_path:path})});
     const data=await res.json();
     if(data.tx_hash){
         log('Tx '+data.tx_hash);


### PR DESCRIPTION
## Summary
- lookup keystore password automatically in `api_deposit_keystore`
- drop password field from KeystoreDepositRequest
- update keystore depositor web page to not ask for password

## Testing
- `python -m py_compile main.py deposit_utils.py deposit.py`

------
https://chatgpt.com/codex/tasks/task_e_686d36e0b798832cb7e92b2d75c0ffc3