### PR TITLE
Enhance keystore view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-keystore/
+keystore/__pycache__/

--- a/static/keystores.html
+++ b/static/keystores.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Keystore Depositor</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/knockout@3.5.1/build/knockout-latest.js"></script>
     <style>
         body { margin: 40px; }
         section { margin-bottom: 2em; }
@@ -16,9 +17,15 @@
     <h2>Wallets</h2>
     <table class="table" id="wallet-table">
         <thead><tr><th>Address</th><th>Balance (ETH)</th></tr></thead>
-        <tbody></tbody>
+        <tbody data-bind="foreach: wallets">
+            <tr>
+                <td data-bind="text: address"></td>
+                <td data-bind="text: balance"></td>
+            </tr>
+        </tbody>
     </table>
-    <select id="wallet-select" class="form-select d-none"></select>
+    <select id="wallet-select" class="form-select d-none"
+            data-bind="options: wallets, optionsText: 'address', optionsValue: 'address', value: selectedWallet"></select>
     <button class="btn btn-secondary" onclick="refreshWallets()">Refresh Wallets</button>
 </section>
 <section>
@@ -26,8 +33,18 @@
     <label class="form-label">Folder <input class="form-control" id="ks-folder" type="text" value="validator_keys"></label>
     <button class="btn btn-primary" onclick="loadKeystores()">Load Keystores</button>
     <table class="table mt-3" id="ks-table">
-        <thead><tr><th>Keystore</th><th>Status</th><th></th></tr></thead>
-        <tbody></tbody>
+        <thead><tr><th>Keystore</th><th>Pubkey</th><th>Version</th><th>Status</th><th></th></tr></thead>
+        <tbody data-bind="foreach: keystores">
+            <tr>
+                <td data-bind="text: path"></td>
+                <td data-bind="text: pubkey"></td>
+                <td data-bind="text: version"></td>
+                <td data-bind="text: used ? 'Used - ' + tx_hash : 'Unused'"></td>
+                <td>
+                    <button class="btn btn-sm btn-success" data-bind="click: $parent.depositKS, enable: !used">Deposit</button>
+                </td>
+            </tr>
+        </tbody>
     </table>
     <pre id="ks-log"></pre>
 </section>
@@ -36,48 +53,53 @@ function log(msg){
     const pre=document.getElementById('ks-log');
     pre.textContent += msg + "\n";
 }
-async function refreshWallets(){
-    const res=await fetch('/wallets');
-    const wallets=await res.json();
-    const sel=document.getElementById('wallet-select');
-    const tbody=document.querySelector('#wallet-table tbody');
-    sel.innerHTML='';
-    tbody.innerHTML='';
-    wallets.forEach(w=>{
-        const opt=document.createElement('option');
-        opt.value=w.address; opt.textContent=w.address; sel.appendChild(opt);
-        const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${w.address}</td><td>${w.balance}</td>`;
-        tbody.appendChild(tr);
+
+const viewModel = {
+    wallets: ko.observableArray([]),
+    keystores: ko.observableArray([]),
+    selectedWallet: ko.observable()
+};
+
+viewModel.depositKS = async function(ks){
+    const addr = viewModel.selectedWallet();
+    if(!addr) return;
+    log('Depositing ' + ks.path);
+    const res = await fetch('/deposit_keystore', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            address: addr,
+            keystore_path: ks.path,
+            secret_path: `${document.getElementById('ks-folder').value}/secrets/${ks.pubkey.toLowerCase()}`
+        })
     });
-}
-async function loadKeystores(){
-    const dir=document.getElementById('ks-folder').value;
-    const res=await fetch('/list_keystores?path='+encodeURIComponent(dir));
-    const list=await res.json();
-    const tbody=document.querySelector('#ks-table tbody');
-    tbody.innerHTML='';
-    list.forEach(ks=>{
-        const tr=document.createElement('tr');
-        let status= ks.used ? `Used - ${ks.tx_hash}` : 'Unused';
-        let btn = ks.used ? '' : `<button class="btn btn-sm btn-success" onclick="depositKS('${ks.path}')">Deposit</button>`;
-        tr.innerHTML=`<td>${ks.path}</td><td>${status}</td><td>${btn}</td>`;
-        tbody.appendChild(tr);
-    });
-}
-async function depositKS(path){
-    const addr=document.getElementById('wallet-select').value;
-    log('Depositing '+path);
-    const res=await fetch('/deposit_keystore',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({address:addr,keystore_path:path, secret_path:`${document.getElementById('ks-folder').value}/secrets/${addr.toLowerCase()}`})});
-    const data=await res.json();
+    const data = await res.json();
     if(data.tx_hash){
-        log('Tx '+data.tx_hash);
+        log('Tx ' + data.tx_hash);
     }
     if(data.already_used){
         log('Keystore already used');
     }
     loadKeystores();
+};
+
+async function refreshWallets(){
+    const res = await fetch('/wallets');
+    const wallets = await res.json();
+    viewModel.wallets(wallets);
+    if(wallets.length > 0){
+        viewModel.selectedWallet(wallets[0].address);
+    }
 }
+
+async function loadKeystores(){
+    const dir = document.getElementById('ks-folder').value;
+    const res = await fetch('/list_keystores?path=' + encodeURIComponent(dir));
+    const list = await res.json();
+    viewModel.keystores(list);
+}
+
+ko.applyBindings(viewModel);
 refreshWallets();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- show keystore `pubkey` and `version` from JSON
- use `pubkey` when forming secret file path
- refresh the UI using Knockout.js
- ignore `__pycache__`

## Testing
- `python -m py_compile main.py deposit.py deposit_utils.py send_deposit_tx.py`


------
https://chatgpt.com/codex/tasks/task_e_686d3d256f0c832ca9553696e3c8411a