### PR TITLE
Add tx links and truncate long values

### DIFF
--- a/static/keystores.html
+++ b/static/keystores.html
@@ -36,10 +36,10 @@
         <thead><tr><th>Keystore</th><th>Pubkey</th><th>Version</th><th>Status</th><th></th></tr></thead>
         <tbody data-bind="foreach: keystores">
             <tr>
-                <td data-bind="text: path"></td>
-                <td data-bind="text: pubkey"></td>
+                <td data-bind="text: truncate(path), attr: {title: path}"></td>
+                <td data-bind="text: truncate(pubkey), attr: {title: pubkey}"></td>
                 <td data-bind="text: version"></td>
-                <td data-bind="text: used ? 'Used - ' + tx_hash : 'Unused'"></td>
+                <td data-bind="html: txLink($data)"></td>
                 <td>
                     <button class="btn btn-sm btn-success" data-bind="click: $parent.depositKS, enable: !used">Deposit</button>
                 </td>
@@ -52,6 +52,18 @@
 function log(msg){
     const pre=document.getElementById('ks-log');
     pre.textContent += msg + "\n";
+}
+
+function truncate(str){
+    if(!str) return '';
+    return str.length > 20 ? str.substring(0,20) + '...' : str;
+}
+
+function txLink(ks){
+    if(ks.used && ks.tx_hash){
+        return 'Used - <a href="https://hoodi.etherscan.io/tx/' + ks.tx_hash + '" target="_blank">' + ks.tx_hash + '</a>';
+    }
+    return 'Unused';
 }
 
 const viewModel = {


### PR DESCRIPTION
## Summary
- shorten long keystore path and pubkey strings in the keystore list
- link used keystores to the tx on hoodi.etherscan

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'getargspec')*

------
https://chatgpt.com/codex/tasks/task_e_686d41497ca8832cb4f7ea60ba9fb732